### PR TITLE
Add passkey plugin docs to website

### DIFF
--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/project-settings",
+  "sourceLanguageTag": "en",
+  "languageTags": ["en", "de", "es", "fr", "id", "it", "ja", "ko", "pl"],
   "baseLocale": "en",
   "locales": ["en", "de", "es", "fr", "id", "it", "ja", "ko", "pl"],
   "modules": ["https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js", "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js"],

--- a/src/config/plugins.ts
+++ b/src/config/plugins.ts
@@ -4898,4 +4898,11 @@ export const actions = [
     description: 'React Native Indicator Component',
     author: 'wangdicoder',
   },
+  {
+    name: '@capgo/capacitor-passkey',
+    href: 'https://github.com/Cap-go/capacitor-passkey',
+    title: '@capgo/capacitor-passkey',
+    description: 'Passkeys for Capacitor with a browser-style WebAuthn shim and build-time native configuration for iOS and Android.',
+    author: 'Cap-go',
+  },
 ]

--- a/src/content/plugins-tutorials/capacitor-passkey.md
+++ b/src/content/plugins-tutorials/capacitor-passkey.md
@@ -1,0 +1,98 @@
+---
+"title": "Use passkeys in Capacitor with @capgo/capacitor-passkey"
+"description": "A step-by-step guide to keep browser-style WebAuthn code in a Capacitor app with the @capgo/capacitor-passkey shim."
+"created_at": "2026-04-13"
+"published": true
+---
+
+# Use passkeys in Capacitor with @capgo/capacitor-passkey
+
+`@capgo/capacitor-passkey` lets a Capacitor app keep the same WebAuthn flow you already use on the web:
+
+```ts
+await navigator.credentials.create({ publicKey: registrationOptions });
+await navigator.credentials.get({ publicKey: requestOptions });
+```
+
+The plugin installs a shim for `navigator.credentials.create()` and `navigator.credentials.get()` on native platforms, forwards the request to iOS and Android passkey APIs, and returns browser-like credential objects back to your app.
+
+## Install the plugin
+
+```bash
+bun add @capgo/capacitor-passkey
+bunx cap sync
+```
+
+## Configure the host app once
+
+Add the plugin config in `capacitor.config.ts` or `capacitor.config.json`:
+
+```ts
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'app.capgo.passkey.example',
+  appName: 'My App',
+  webDir: 'dist',
+  plugins: {
+    CapacitorPasskey: {
+      origin: 'https://signin.example.com',
+      autoShim: true,
+      domains: ['signin.example.com'],
+    },
+  },
+};
+
+export default config;
+```
+
+Run sync again after changing the config:
+
+```bash
+bunx cap sync
+```
+
+During sync, the plugin patches the generated native host projects:
+
+- iOS: associated domains entitlements
+- Android: `asset_statements` metadata for Digital Asset Links
+
+## Import the shim once
+
+Import the auto entrypoint in your app bootstrap:
+
+```ts
+import '@capgo/capacitor-passkey/auto';
+```
+
+After that, your existing browser-style passkey code can stay the same.
+
+## Keep your normal WebAuthn flow
+
+```ts
+const credential = await navigator.credentials.create({
+  publicKey: registrationOptions,
+});
+
+const assertion = await navigator.credentials.get({
+  publicKey: requestOptions,
+});
+```
+
+## Native setup still needs website files
+
+The plugin reduces app-side work, but passkeys still depend on the website trust files for your relying-party domain:
+
+- iOS needs `/.well-known/apple-app-site-association`
+- Android needs `/.well-known/assetlinks.json`
+
+The full platform setup is documented here:
+
+- [Getting started](/docs/plugins/passkey/getting-started/)
+- [iOS setup](/docs/plugins/passkey/ios/)
+- [Android setup](/docs/plugins/passkey/android/)
+- [Backend notes](/docs/plugins/passkey/backend/)
+
+## Important Android caveat
+
+Android Credential Manager can share the same relying party and passkeys as your website when Digital Asset Links are configured, but the native assertion origin is not identical to a browser origin. If your backend strictly validates `clientDataJSON.origin`, make sure it accepts the Android app origin alongside your website origin.

--- a/src/layouts/PasskeyDocsLayout.astro
+++ b/src/layouts/PasskeyDocsLayout.astro
@@ -1,0 +1,80 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import '@/css/docs.css'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+
+interface NavItem {
+  key: string
+  label: string
+  href: string
+}
+
+const {
+  pageTitle,
+  pageDescription,
+  current,
+}: {
+  pageTitle: string
+  pageDescription: string
+  current: string
+} = Astro.props
+
+const content = {
+  title: pageTitle,
+  description: pageDescription,
+}
+
+const navItems: NavItem[] = [
+  { key: 'index', label: 'Overview', href: 'docs/plugins/passkey' },
+  { key: 'getting-started', label: 'Getting started', href: 'docs/plugins/passkey/getting-started' },
+  { key: 'ios', label: 'iOS setup', href: 'docs/plugins/passkey/ios' },
+  { key: 'android', label: 'Android setup', href: 'docs/plugins/passkey/android' },
+  { key: 'backend', label: 'Backend notes', href: 'docs/plugins/passkey/backend' },
+]
+---
+
+<Layout {content}>
+  <div class="mx-auto w-full max-w-6xl px-6 py-16">
+    <div class="mb-8 text-sm text-white/60">
+      <a href={getRelativeLocaleUrl(Astro.locals.locale, '')} class="hover:text-white">Home</a>
+      <span class="mx-2">/</span>
+      <span>Docs</span>
+      <span class="mx-2">/</span>
+      <span>Plugins</span>
+      <span class="mx-2">/</span>
+      <span>Passkey</span>
+    </div>
+
+    <div class="grid gap-8 lg:grid-cols-[240px_minmax(0,1fr)]">
+      <aside class="h-fit rounded-xl border border-white/10 bg-white/5 p-4">
+        <div class="mb-3 text-sm font-semibold tracking-[0.18em] text-white/70 uppercase">Passkey Docs</div>
+        <nav class="flex flex-col gap-2">
+          {
+            navItems.map((item) => {
+              const isActive = item.key === current
+              return (
+                <a
+                  href={getRelativeLocaleUrl(Astro.locals.locale, item.href)}
+                  class:list={['rounded-lg px-3 py-2 text-sm transition-colors', isActive ? 'text-codepushgo-900 bg-white' : 'text-white/70 hover:bg-white/10 hover:text-white']}
+                >
+                  {item.label}
+                </a>
+              )
+            })
+          }
+        </nav>
+      </aside>
+
+      <main class="min-w-0">
+        <div class="mb-8">
+          <h1 class="text-4xl font-bold text-white">{pageTitle}</h1>
+          <p class="mt-3 max-w-3xl text-lg text-white/70">{pageDescription}</p>
+        </div>
+
+        <article class="prose prose-invert max-w-none">
+          <slot />
+        </article>
+      </main>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/docs/plugins/passkey/android.astro
+++ b/src/pages/docs/plugins/passkey/android.astro
@@ -1,0 +1,57 @@
+---
+import PasskeyDocsLayout from '@/layouts/PasskeyDocsLayout.astro'
+---
+
+<PasskeyDocsLayout
+  pageTitle="Android Setup"
+  pageDescription="Configure passkeys on Android for @capgo/capacitor-passkey with Digital Asset Links and assetlinks.json."
+  current="android"
+>
+  <p>On Android, passkeys work with your website when the app and the relying-party domain are connected through Digital Asset Links.</p>
+
+  <h2>What the plugin handles</h2>
+  <p>After you add the plugin config and run <code>bunx cap sync</code>, the plugin patches the generated Android host project.</p>
+
+  <ul>
+    <li>injects the <code>asset_statements</code> manifest metadata</li>
+    <li>writes the generated string resource referenced by that metadata</li>
+  </ul>
+
+  <h2>What you still need to host</h2>
+  <p>You must publish <code>assetlinks.json</code> on the relying-party domain.</p>
+
+  <pre><code>{`https://signin.example.com/.well-known/assetlinks.json`}</code></pre>
+
+  <p>Example:</p>
+  <pre><code>{`[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "app.capgo.passkey.example",
+      "sha256_cert_fingerprints": [
+        "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
+      ]
+    }
+  }
+]`}</code></pre>
+
+  <h2>Checklist</h2>
+  <ol>
+    <li>Set <code>origin</code> and <code>domains</code> in <code>plugins.CapacitorPasskey</code> in <code>capacitor.config.*</code>.</li>
+    <li>Run <code>bunx cap sync</code>.</li>
+    <li>Use your real Android package name in <code>assetlinks.json</code>.</li>
+    <li>Add every signing certificate fingerprint you need, including debug or internal signing keys if you test those builds.</li>
+    <li>Host the file on the same domain you use as the relying-party ID.</li>
+  </ol>
+
+  <h2>Important behavior difference from a browser</h2>
+  <ul>
+    <li>A normal Android app does not behave like a privileged browser.</li>
+    <li>The assertion origin can be tied to the Android app signature instead of your website origin.</li>
+    <li>If your backend strictly validates <code>clientDataJSON.origin</code>, accept the Android app origin alongside the website origin.</li>
+  </ul>
+</PasskeyDocsLayout>

--- a/src/pages/docs/plugins/passkey/backend.astro
+++ b/src/pages/docs/plugins/passkey/backend.astro
@@ -1,0 +1,48 @@
+---
+import PasskeyDocsLayout from '@/layouts/PasskeyDocsLayout.astro'
+---
+
+<PasskeyDocsLayout
+  pageTitle="Backend Notes"
+  pageDescription="Understand the backend contract for @capgo/capacitor-passkey, including WebAuthn challenge handling and Android origin validation."
+  current="backend"
+>
+  <p>Your backend still owns the normal WebAuthn ceremony.</p>
+
+  <ul>
+    <li>generate registration and authentication challenges</li>
+    <li>verify attestation and assertion responses</li>
+    <li>enforce relying-party ID and challenge validation</li>
+    <li>store credentials and counters the same way you would for a browser flow</li>
+  </ul>
+
+  <h2>What stays the same</h2>
+  <ul>
+    <li>On the web, the plugin forwards to the real browser WebAuthn API.</li>
+    <li>On native Capacitor, it returns browser-like credential objects backed by native passkey APIs.</li>
+    <li>Your backend can keep the same challenge and verification pipeline.</li>
+  </ul>
+
+  <h2>What changes on Android</h2>
+  <ul>
+    <li>Digital Asset Links let Android share the same relying party and credential ecosystem as your website.</li>
+    <li>The literal <code>clientDataJSON.origin</code> value can still differ from the website origin.</li>
+    <li>If your server rejects anything except <code>https://your-domain</code>, Android native assertions can fail even when the passkey is otherwise valid.</li>
+  </ul>
+
+  <h2>Recommended backend rule</h2>
+  <p>Allow the expected browser origin and the expected Android app origin for the same relying party when you support native Android passkeys.</p>
+
+  <h2>If you need direct JSON-safe calls</h2>
+  <pre><code>{`import { CapacitorPasskey } from '@capgo/capacitor-passkey';
+
+const registration = await CapacitorPasskey.createCredential({
+  origin: 'https://signin.example.com',
+  publicKey: registrationOptionsFromBackend,
+});
+
+const authentication = await CapacitorPasskey.getCredential({
+  origin: 'https://signin.example.com',
+  publicKey: requestOptionsFromBackend,
+});`}</code></pre>
+</PasskeyDocsLayout>

--- a/src/pages/docs/plugins/passkey/getting-started.astro
+++ b/src/pages/docs/plugins/passkey/getting-started.astro
@@ -1,0 +1,88 @@
+---
+import PasskeyDocsLayout from '@/layouts/PasskeyDocsLayout.astro'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+
+const iosHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/plugins/passkey/ios')
+const androidHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/plugins/passkey/android')
+const backendHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/plugins/passkey/backend')
+---
+
+<PasskeyDocsLayout
+  pageTitle="Getting Started"
+  pageDescription="Install @capgo/capacitor-passkey, configure the plugin once, and keep your browser-style WebAuthn code in a Capacitor app."
+  current="getting-started"
+>
+  <h2>1. Install the package</h2>
+  <pre><code>{`bun add @capgo/capacitor-passkey
+bunx cap sync`}</code></pre>
+
+  <h2>2. Add the plugin config</h2>
+  <p>The plugin reads its setup from <code>plugins.CapacitorPasskey</code> in your Capacitor config.</p>
+
+  <pre><code>{`import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'app.capgo.passkey.example',
+  appName: 'My App',
+  webDir: 'dist',
+  plugins: {
+    CapacitorPasskey: {
+      origin: 'https://signin.example.com',
+      autoShim: true,
+      domains: ['signin.example.com'],
+    },
+  },
+};
+
+export default config;`}</code></pre>
+
+  <p>After changing the config, sync again:</p>
+  <pre><code>{`bunx cap sync`}</code></pre>
+
+  <h2>3. Import the shim once</h2>
+  <pre><code>{`import '@capgo/capacitor-passkey/auto';`}</code></pre>
+
+  <p>
+    After that import is in your app bootstrap, native Capacitor builds can keep using the browser-style WebAuthn entry points instead of rewriting your app around a custom passkey
+    API.
+  </p>
+
+  <h2>4. Keep your existing WebAuthn flow</h2>
+  <pre><code>{`const registration = await navigator.credentials.create({
+  publicKey: registrationOptions,
+});
+
+const authentication = await navigator.credentials.get({
+  publicKey: requestOptions,
+});`}</code></pre>
+
+  <h2>What the config does</h2>
+  <ul>
+    <li><code>origin</code>: primary HTTPS relying-party origin used by the shim and the direct plugin API</li>
+    <li><code>domains</code>: hostnames that the sync hook patches into native platform config</li>
+    <li><code>autoShim</code>: enables automatic browser-style shim installation when you use <code>@capgo/capacitor-passkey/auto</code></li>
+  </ul>
+
+  <h2>What sync patches for you</h2>
+  <ul>
+    <li>iOS: associated domains entitlements and Xcode entitlements wiring when needed</li>
+    <li>Android: <code>asset_statements</code> metadata and the generated string resource referenced by the manifest</li>
+  </ul>
+
+  <p>The sync hook does not publish the website trust files for you. You still need the relying-party domain to serve the correct files.</p>
+
+  <div class="not-prose mt-8 grid gap-4 md:grid-cols-3">
+    <a href={iosHref} class="rounded-xl border border-white/10 bg-white/5 p-5 text-white no-underline transition-colors hover:border-white/20 hover:bg-white/10">
+      <div class="text-lg font-semibold">iOS setup</div>
+      <p class="mt-2 text-sm text-white/70">Associated Domains and <code>apple-app-site-association</code>.</p>
+    </a>
+    <a href={androidHref} class="rounded-xl border border-white/10 bg-white/5 p-5 text-white no-underline transition-colors hover:border-white/20 hover:bg-white/10">
+      <div class="text-lg font-semibold">Android setup</div>
+      <p class="mt-2 text-sm text-white/70">Digital Asset Links and <code>assetlinks.json</code>.</p>
+    </a>
+    <a href={backendHref} class="rounded-xl border border-white/10 bg-white/5 p-5 text-white no-underline transition-colors hover:border-white/20 hover:bg-white/10">
+      <div class="text-lg font-semibold">Backend notes</div>
+      <p class="mt-2 text-sm text-white/70">Origin validation and Android-specific behavior.</p>
+    </a>
+  </div>
+</PasskeyDocsLayout>

--- a/src/pages/docs/plugins/passkey/index.astro
+++ b/src/pages/docs/plugins/passkey/index.astro
@@ -1,0 +1,48 @@
+---
+import PasskeyDocsLayout from '@/layouts/PasskeyDocsLayout.astro'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+
+const gettingStartedHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/plugins/passkey/getting-started')
+const iosHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/plugins/passkey/ios')
+const androidHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/plugins/passkey/android')
+const backendHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/plugins/passkey/backend')
+---
+
+<PasskeyDocsLayout
+  pageTitle="@capgo/capacitor-passkey"
+  pageDescription="Passkeys for Capacitor with a browser-style WebAuthn shim, minimal JavaScript changes, and native setup generated during sync."
+  current="index"
+>
+  <p>
+    <code>@capgo/capacitor-passkey</code> lets a Capacitor app keep the same WebAuthn flow you already use on the web while the plugin handles the native passkey calls on iOS and Android.
+  </p>
+
+  <pre><code>{`await navigator.credentials.create({ publicKey: registrationOptions });
+await navigator.credentials.get({ publicKey: requestOptions });`}</code></pre>
+
+  <div class="not-prose mt-8 grid gap-4 md:grid-cols-2">
+    <a href={gettingStartedHref} class="rounded-xl border border-white/10 bg-white/5 p-5 text-white no-underline transition-colors hover:border-white/20 hover:bg-white/10">
+      <div class="text-sm font-semibold tracking-[0.18em] text-white/60 uppercase">Start Here</div>
+      <div class="mt-2 text-xl font-semibold">@capgo/capacitor-passkey setup</div>
+      <p class="mt-2 text-sm text-white/70">Install the plugin, add one config block, import the shim once, and keep your browser-style code.</p>
+    </a>
+
+    <a href={iosHref} class="rounded-xl border border-white/10 bg-white/5 p-5 text-white no-underline transition-colors hover:border-white/20 hover:bg-white/10">
+      <div class="text-sm font-semibold tracking-[0.18em] text-white/60 uppercase">iOS</div>
+      <div class="mt-2 text-xl font-semibold">Associated Domains</div>
+      <p class="mt-2 text-sm text-white/70">What the plugin patches in the generated host app and what still has to live on your website.</p>
+    </a>
+
+    <a href={androidHref} class="rounded-xl border border-white/10 bg-white/5 p-5 text-white no-underline transition-colors hover:border-white/20 hover:bg-white/10">
+      <div class="text-sm font-semibold tracking-[0.18em] text-white/60 uppercase">Android</div>
+      <div class="mt-2 text-xl font-semibold">Digital Asset Links</div>
+      <p class="mt-2 text-sm text-white/70">How the plugin wires the Android host app and what has to be published in <code>assetlinks.json</code>.</p>
+    </a>
+
+    <a href={backendHref} class="rounded-xl border border-white/10 bg-white/5 p-5 text-white no-underline transition-colors hover:border-white/20 hover:bg-white/10">
+      <div class="text-sm font-semibold tracking-[0.18em] text-white/60 uppercase">Backend</div>
+      <div class="mt-2 text-xl font-semibold">Verification Notes</div>
+      <p class="mt-2 text-sm text-white/70">Keep the normal WebAuthn ceremony and account for Android origin validation differences where needed.</p>
+    </a>
+  </div>
+</PasskeyDocsLayout>

--- a/src/pages/docs/plugins/passkey/ios.astro
+++ b/src/pages/docs/plugins/passkey/ios.astro
@@ -1,0 +1,47 @@
+---
+import PasskeyDocsLayout from '@/layouts/PasskeyDocsLayout.astro'
+---
+
+<PasskeyDocsLayout
+  pageTitle="iOS Setup"
+  pageDescription="Configure passkeys on iOS for @capgo/capacitor-passkey with Associated Domains and the apple-app-site-association file."
+  current="ios"
+>
+  <p>On iOS, passkeys only work when the app is associated with the same relying-party domain as the website.</p>
+
+  <h2>What the plugin handles</h2>
+  <p>After you add the plugin config and run <code>bunx cap sync</code>, the plugin patches the generated iOS host project so you do not need to keep editing it manually.</p>
+
+  <ul>
+    <li>adds the <code>webcredentials:</code> associated-domains entries for the configured domains</li>
+    <li>wires <code>CODE_SIGN_ENTITLEMENTS</code> when the generated app target does not already point at an entitlements file</li>
+  </ul>
+
+  <h2>What you still need to host</h2>
+  <p>You must publish <code>apple-app-site-association</code> on the relying-party domain.</p>
+
+  <pre><code>{`https://signin.example.com/.well-known/apple-app-site-association`}</code></pre>
+
+  <p>Example:</p>
+  <pre><code>{`{
+  "webcredentials": {
+    "apps": ["ABCDE12345.app.capgo.passkey.example"]
+  }
+}`}</code></pre>
+
+  <h2>Checklist</h2>
+  <ol>
+    <li>Set <code>origin</code> and <code>domains</code> in <code>plugins.CapacitorPasskey</code> in <code>capacitor.config.*</code>.</li>
+    <li>Run <code>bunx cap sync</code>.</li>
+    <li>Confirm your Apple Team ID and app bundle ID, then build the <code>TEAMID.bundleId</code> value for the association file.</li>
+    <li>Host <code>apple-app-site-association</code> with HTTP 200 and no <code>.json</code> extension.</li>
+    <li>Make sure the relying-party ID used by your backend matches the associated domain.</li>
+  </ol>
+
+  <h2>Notes</h2>
+  <ul>
+    <li>The website file must be served from the exact passkey domain you use as the relying-party ID.</li>
+    <li>On iOS 17.4 and newer, the plugin uses the browser-style client-data API so the configured HTTPS origin is reflected in <code>clientDataJSON</code>.</li>
+    <li>The plugin can patch native project files during sync, but it cannot create or host the website association file on your domain.</li>
+  </ul>
+</PasskeyDocsLayout>


### PR DESCRIPTION
## Summary
- add `@capgo/capacitor-passkey` to the plugin list
- add a new passkey tutorial under `/tutorials/capacitor-passkey`
- add live website docs under `/docs/plugins/passkey/*`

## Validation
- bun run fmt
- bun run build
