### PR TITLE
Revert autoUpdate docs from wrong repo

### DIFF
--- a/src/content/docs/docs/cli/commands.mdx
+++ b/src/content/docs/docs/cli/commands.mdx
@@ -125,7 +125,7 @@ Optionally, you can give:
 Edit the Capacitor config.
 
 `[path]` - path of the setting that you would like to change. For example, to change the `appId`, provide `appId`. 
-If you wish to disable auto update in the `capacitor-updater` provide `plugins.CapacitorUpdater.autoUpdate` with `--string off`.
+If you wish to disable auto update in the `capacitor-updater` provide `plugins.CapacitorUpdater.autoUpdate`
 
 You MUST provide either `--string` or `--bool`!
 

--- a/src/content/docs/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/docs/getting-started/add-an-app.mdx
@@ -47,7 +47,7 @@ In case the init command doesn't work for you, you can manually add an app.
 
 3. Install the plugin in your app: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-4. Configure the plugin in your `capacitor.config` <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": "atBackground",\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
+4. Configure the plugin in your `capacitor.config` <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [See all option available](/docs/plugin/settings/). This informations will be infer if not provided.
 
 5. Call the init method as early as possible in your app: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />

--- a/src/content/docs/docs/live-updates/update-behavior.mdx
+++ b/src/content/docs/docs/live-updates/update-behavior.mdx
@@ -93,9 +93,9 @@ Note that the `kill` condition currently triggers the update after the first kil
 
 ## Applying Updates Immediately
 
-For critical updates or apps with very simple state, you may want to apply an update as soon as it's downloaded, without waiting for a background or kill event. CodePushGo supports this with the `autoUpdate` policy modes.
+For critical updates or apps with very simple state, you may want to apply an update as soon as it's downloaded, without waiting for a background or kill event. CodePushGo supports this via the `directUpdate` configuration option.
 
-Use `autoUpdate: "always"` in your `capacitor.config.ts` file:
+`directUpdate` is set in your `capacitor.config.ts` file, not in JavaScript code:
 
 ```typescript
 import { CapacitorConfig } from '@capacitor/cli';
@@ -103,20 +103,21 @@ import { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   plugins: {
     CapacitorUpdater: {
-      autoUpdate: 'always',
-      keepUrlPathAfterReload: true,
+      autoUpdate: true,
+      directUpdate: true,
     },
   },
+  keepUrlPathAfterReload: true,
 };
 
 export default config;
 ```
 
-With `autoUpdate: "always"`, CodePushGo will immediately apply an update as soon as the download completes, even if the user is actively using the app.
+With `directUpdate` enabled, CodePushGo will immediately apply an update as soon as the download completes, even if the user is actively using the app.
 
-Note that because this is a native configuration, it requires some additional handling in your JavaScript code.
+Note that because `directUpdate` is a native configuration, it requires some additional handling in your JavaScript code.
 
-When using an immediate apply mode, you need to listen for the `appReady` event and hide your app's splash screen in response:
+When using `directUpdate`, you need to listen for the `appReady` event and hide your app's splash screen in response:
 
 ```js
 import { CapacitorUpdater } from '@capgo/capacitor-updater';
@@ -132,42 +133,22 @@ CapacitorUpdater.notifyAppReady();
 
 The `appReady` event fires once the app has finished initializing and applying any pending updates. This is the point at which it's safe to show your app's UI, as it ensures the user will see the latest version.
 
-In addition to handling the `appReady` event, we recommend setting the `keepUrlPathAfterReload` configuration option to `true` when using `autoUpdate: "always"`. This preserves the current URL path when the app is reloaded due to an update, helping maintain the user's location in the app and reducing disorientation.
+In addition to handling the `appReady` event, we recommend setting the `keepUrlPathAfterReload` configuration option to `true` when using `directUpdate`. This preserves the current URL path when the app is reloaded due to an update, helping maintain the user's location in the app and reducing disorientation.
 
-If you don't handle the `appReady` event and set `keepUrlPathAfterReload` when using `autoUpdate: "always"`, the user may briefly see a stale version of the app, be taken back to the initial route, or see a flicker as the update is applied.
+If you don't handle the `appReady` event and set `keepUrlPathAfterReload` when using `directUpdate`, the user may briefly see a stale version of the app, be taken back to the initial route, or see a flicker as the update is applied.
 
-Using `autoUpdate: "always"` can be useful for delivering critical bug fixes or security patches, but it comes with some tradeoffs:
+Using `directUpdate` can be useful for delivering critical bug fixes or security patches, but it comes with some tradeoffs:
 
 - The user may see a brief flicker or loading state as the update is applied if you don't properly handle the `appReady` event.
 - If the update modifies the app state or UI, the user may see a disruptive change in the middle of a session.
 - The user's location in the app may be lost if `keepUrlPathAfterReload` is not set, potentially disorienting them.
 - You'll need to carefully handle saving and restoring state to ensure a smooth transition.
 
-If you do enable `autoUpdate: "always"`, we recommend:
+If you do enable `directUpdate`, we recommend:
 
 - Handling the `appReady` event to control when your app's UI is shown.
 - Setting `keepUrlPathAfterReload` to `true` to preserve the user's location in the app.
 - Saving and restoring the app state as needed to avoid losing user progress.
 - Thoroughly testing your app's update behavior to ensure there are no jarring transitions, lost state, or disorienting location changes.
-
-## Downloading Automatically Without Applying
-
-Use `autoUpdate: "onlyDownload"` when you want CodePushGo to check and download updates automatically but never apply them without your JavaScript code.
-
-```typescript
-import { CapacitorConfig } from '@capacitor/cli';
-
-const config: CapacitorConfig = {
-  plugins: {
-    CapacitorUpdater: {
-      autoUpdate: 'onlyDownload',
-    },
-  },
-};
-
-export default config;
-```
-
-With this mode, the plugin emits `updateAvailable` after the bundle is downloaded. You can then show your own UI, wait for the user to finish a task, and call `CapacitorUpdater.set()` when you are ready.
 
 In most cases, the default update behavior provides the best balance of delivering updates quickly and minimizing disruption. But for apps with specific needs, CodePushGo provides the flexibility to customize when and how updates are applied.

--- a/src/content/docs/docs/plugin/api.md
+++ b/src/content/docs/docs/plugin/api.md
@@ -20,14 +20,14 @@ CapacitorUpdater can be configured with these options:
 | **`responseTimeout`**        | <code>number</code>  | Configure the number of milliseconds the native plugin should wait before considering API timeout. Only available for Android and iOS.                                                          | <code>20 // (20 second)</code>                     |         |
 | **`autoDeleteFailed`**       | <code>boolean</code> | Configure whether the plugin should use automatically delete failed bundles. Only available for Android and iOS.                                                                                | <code>true</code>                                  |         |
 | **`autoDeletePrevious`**     | <code>boolean</code> | Configure whether the plugin should use automatically delete previous bundles after a successful update. Only available for Android and iOS.                                                    | <code>true</code>                                  |         |
-| **`autoUpdate`**             | <code>boolean \| 'off' \| 'atBackground' \| 'atInstall' \| 'onLaunch' \| 'always' \| 'onlyDownload'</code> | Configure how the plugin should use Auto Update via an update server. `true` is the same as `"atBackground"` and `false` is the same as `"off"`. `"onlyDownload"` checks and downloads updates automatically, emits `updateAvailable`, and never applies them automatically. Only available for Android and iOS. | <code>true</code>                                  |         |
+| **`autoUpdate`**             | <code>boolean</code> | Configure whether the plugin should use Auto Update via an update server. Only available for Android and iOS.                                                                                   | <code>true</code>                                  |         |
 | **`resetWhenUpdate`**        | <code>boolean</code> | Automatically delete previous downloaded bundles when a newer native app bundle is installed to the device. Only available for Android and iOS.                                                 | <code>true</code>                                  |         |
 | **`updateUrl`**              | <code>string</code>  | Configure the URL / endpoint to which update checks are sent. Only available for Android and iOS.                                                                                               | <code>https://plugin.capgo.app/updates</code>      |         |
 | **`channelUrl`**             | <code>string</code>  | Configure the URL / endpoint for channel operations. Only available for Android and iOS.                                                                                                        | <code>https://plugin.capgo.app/channel_self</code> |         |
 | **`statsUrl`**               | <code>string</code>  | Configure the URL / endpoint to which update statistics are sent. Only available for Android and iOS. Set to "" to disable stats reporting.                                                     | <code>https://plugin.capgo.app/stats</code>        |         |
 | **`publicKey`**              | <code>string</code>  | Configure the public key for end to end live update encryption Version 2 Only available for Android and iOS.                                                                                    | <code>undefined</code>                             | 6.2.0   |
 | **`version`**                | <code>string</code>  | Configure the current version of the app. This will be used for the first update request. If not set, the plugin will get the version from the native code. Only available for Android and iOS. | <code>undefined</code>                             | 4.17.48 |
-| **`directUpdate`**           | <code>boolean \| 'atInstall' \| 'always' \| 'onLaunch'</code> | Deprecated. Use the `autoUpdate` string modes instead. Still supported for backward compatibility. Only available for Android and iOS.                                                          | <code>false</code>                                 | 5.1.0   |
+| **`directUpdate`**           | <code>boolean</code> | Make the plugin direct install the update when the app what just updated/installed. Only for autoUpdate mode. Only available for Android and iOS.                                               | <code>undefined</code>                             | 5.1.0   |
 | **`periodCheckDelay`**       | <code>number</code>  | Configure the delay period for period update check. the unit is in seconds. Only available for Android and iOS. Cannot be less than 600 seconds (10 minutes).                                   | <code>600 // (10 minutes)</code>                   |         |
 | **`localS3`**                | <code>boolean</code> | Configure the CLI to use a local server for testing or self-hosted update server.                                                                                                               | <code>undefined</code>                             | 4.17.48 |
 | **`localHost`**              | <code>string</code>  | Configure the CLI to use a local server for testing or self-hosted update server.                                                                                                               | <code>undefined</code>                             | 4.17.48 |
@@ -53,7 +53,7 @@ In `capacitor.config.json`:
       "responseTimeout": 10 // (10 second),
       "autoDeleteFailed": false,
       "autoDeletePrevious": false,
-      "autoUpdate": "onlyDownload",
+      "autoUpdate": false,
       "resetWhenUpdate": false,
       "updateUrl": https://example.com/api/auto_update,
       "channelUrl": https://example.com/api/channel,
@@ -92,7 +92,7 @@ const config: CapacitorConfig = {
       responseTimeout: 10 // (10 second),
       autoDeleteFailed: false,
       autoDeletePrevious: false,
-      autoUpdate: 'onlyDownload',
+      autoUpdate: false,
       resetWhenUpdate: false,
       updateUrl: https://example.com/api/auto_update,
       channelUrl: https://example.com/api/channel,

--- a/src/content/docs/docs/plugin/cloud-mode/auto-update.md
+++ b/src/content/docs/docs/plugin/cloud-mode/auto-update.md
@@ -21,7 +21,7 @@ New way: Use the `version` field in your `capacitor.config.json` file.
 {
   "plugins": {
     "CapacitorUpdater": {
-      "autoUpdate": "atBackground", // Enable auto-update, true keeps this same behavior
+      "autoUpdate": true, // Enable auto-update, true by default
       "appId": "com.example.app", // Used to identify the app in the server
       "version": "1.0.0" // Used to check for updates
     }
@@ -96,9 +96,9 @@ CapacitorUpdater.notifyAppReady()
 #### Dev flow
 
 When you develop new features, be sure to block `autoUpdate`, as CodePushGo will constatly overwrite your work with the latest update bundle.
-Set `autoUpdate` to `"off"` in your config.
+Set `autoUpdate` to false in your config. 
 If for some reason you are stuck on an update, you can delete the app and reinstall it.
-Be sure to set `autoUpdate` to `"off"` in your config before doing so.
+Be sure to set `autoUpdate` to false in your config before doing so.
 And then build it again with Xcode or Android studio.
 
 To upload the version at each commit setup CI/CD with this guide

--- a/src/content/docs/docs/plugin/cloud-mode/hybrid-update.md
+++ b/src/content/docs/docs/plugin/cloud-mode/hybrid-update.md
@@ -14,7 +14,7 @@ When pushing updates to your user you have a few ways to deal with the update cy
 
 ## Silent update
 
-You can force an update cycle to happen at every app start by setting `autoUpdate` to `"always"`,
+You can force an update cycle to happen at every app start by setting `directUpdate` to `true`,
 this will trigger the update cycle as usual without the user interaction.
 
 ```tsx
@@ -24,7 +24,7 @@ this will trigger the update cycle as usual without the user interaction.
 	"appName": "Name",
 	"plugins": {
 		"CapacitorUpdater": {
-			"autoUpdate": "always",
+			"directUpdate": true,
 		},
     "SplashScreen": {
       "launchAutoHide": false,
@@ -49,18 +49,7 @@ CapacitorUpdater.notifyAppReady()
 
 ## Force update
 
-Use `"onlyDownload"` if you want the plugin to download updates automatically, then add a listener to the event `updateAvailable` and show an alert to let the user know the app will update:
-
-```tsx
-// capacitor.config.json
-{
-	"plugins": {
-		"CapacitorUpdater": {
-			"autoUpdate": "onlyDownload"
-		}
-	}
-}
-```
+Add a listener to the event `updateAvailable` and then show an alert to let the user know the app will update:
 
 ```js
 import { CapacitorUpdater } from '@capgo/capacitor-updater'

--- a/src/content/docs/docs/plugin/cloud-mode/manual-update.mdx
+++ b/src/content/docs/docs/plugin/cloud-mode/manual-update.mdx
@@ -27,7 +27,7 @@ Disable auto-update in your ```capacitor.confg.json```
 	"appName": "Name",
 	"plugins": {
 		"CapacitorUpdater": {
-			"autoUpdate": "off"
+			"autoUpdate": false
 		}
 	}
 }

--- a/src/content/docs/docs/plugin/self-hosted/manual-update.mdx
+++ b/src/content/docs/docs/plugin/self-hosted/manual-update.mdx
@@ -15,7 +15,7 @@ Add this to your ``capacitor.config.json``, to disable auto-update.
 	"appName": "Name",
 	"plugins": {
 		"CapacitorUpdater": {
-			"autoUpdate": "off",
+			"autoUpdate": false,
 		}
 	}
 }

--- a/src/content/docs/docs/plugin/settings.md
+++ b/src/content/docs/docs/plugin/settings.md
@@ -83,40 +83,24 @@ Default: `true`
 }
 ```
 
-## `autoUpdate`
+## `autoUpdate` 
 
-> Configure how the plugin should use Auto Update via an update server.
+> Configure whether the plugin should use Auto Update via an update server.
 
 Only available for Android and iOS.
 
 Default: `true`
-
-Boolean values keep their previous behavior:
-
-- `true`: same as `"atBackground"`
-- `false`: same as `"off"`
-
-String values let you choose the full update policy:
-
-- `"off"`: disable Auto Update.
-- `"atBackground"`: check and download updates automatically, then apply them the next time the app moves to background.
-- `"atInstall"`: direct install only after app install or native app update, otherwise use `"atBackground"` behavior.
-- `"onLaunch"`: direct install on app launch, otherwise use `"atBackground"` behavior after the first launch attempt.
-- `"always"`: direct install whenever Auto Update runs.
-- `"onlyDownload"`: check and download updates automatically and emit `updateAvailable`, but never direct install or set the next bundle automatically.
 
 ```json
 // capacitor.config.json
 {
   "plugins": {
     "CapacitorUpdater": {
-      "autoUpdate": "onlyDownload"
+      "autoUpdate": false
     }
   }
 }
 ```
-
-Use `"onlyDownload"` when you want Capgo to download updates in the background but keep full control over when the app applies them.
 
 ## `updateUrl` 
 
@@ -177,22 +161,21 @@ Default: `undefined`
 }
 ```
 
-## `directUpdate`
+## `directUpdate` 
 
-> Deprecated. Use the `autoUpdate` string modes instead.
-
-The old `directUpdate` setting is still supported for backward compatibility, but new configuration should use `autoUpdate: "atInstall"`, `autoUpdate: "onLaunch"`, or `autoUpdate: "always"`.
+> Make the plugin directly install the update when the app what just updated/installed. Only applicable for autoUpdate mode.
 
 Only available for Android and iOS.
 
-Default: `false`
+Default: `undefined`
 
 ```json
 // capacitor.config.json
 {
   "plugins": {
     "CapacitorUpdater": {
-      "autoUpdate": "always"
+      "autoUpdate": true,
+      "directUpdate": true
     }
   }
 }
@@ -214,8 +197,27 @@ To configure the plugin, use these settings:
 {
   "plugins": {
     "CapacitorUpdater": {
-      "autoUpdate": "atBackground",
+      "autoUpdate": true,
       "resetWhenUpdate": false
+    }
+  }
+}
+```
+
+## `directUpdate`
+Make the plugin directly install the update when the app what just updated/installed. Only applicable for autoUpdate mode.
+
+:::caution
+This setting require you to hide the app from the user while the update is being installed. Otherwise the app will reset when the user is navigating.
+:::
+
+```json
+// capacitor.config.json
+{
+  "plugins": {
+    "CapacitorUpdater": {
+      "autoUpdate": true,
+      "directUpdate": true
     }
   }
 }

--- a/src/content/docs/docs/upgrade/from-appflow-to-capgo.mdx
+++ b/src/content/docs/docs/upgrade/from-appflow-to-capgo.mdx
@@ -36,7 +36,8 @@ If using AppFlow's default background updates:
 {
   plugins: {
     CapacitorUpdater: {
-      autoUpdate: 'atBackground',
+      autoUpdate: true,
+      directUpdate: false,
       autoDeletePrevious: true
     }
   }
@@ -51,7 +52,8 @@ If using AppFlow's force update strategy:
 {
   plugins: {
     CapacitorUpdater: {
-      autoUpdate: 'always',
+      autoUpdate: true,
+      directUpdate: true,
       keepUrlPathAfterReload: true
     }
   }
@@ -149,7 +151,7 @@ Add CodePushGo configuration to your `capacitor.config.json`:
 {
   "plugins": {
     "CapacitorUpdater": {
-      "autoUpdate": "atBackground"
+      "autoUpdate": true
     }
   }
 }


### PR DESCRIPTION
## What
- Reverts the autoUpdate documentation changes that were merged into the CodePushGo website by mistake.
- Keeps the Node 22 deploy workflow fix from the previous merge.

## Why
- These docs belong in Cap-go/website, not CodePushGo/website.

## How
- Reverted the merged docs commit and restored the workflow file from main so only the docs are removed.

## Testing
- Will verify with GitHub CI on this PR.

## Not Tested
- No local app build was run for this revert-only cleanup.